### PR TITLE
get_rocm_arch(): check PYTORCH_ROCM_ARCH before shelling out to rocminfo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,24 @@ import subprocess
 
 def get_rocm_arch():
     """
-    Runs rocminfo and extracts the GPU architecture (gfx code).
-    
+    Resolves the GPU architecture (gfx code) to build for.
+
+    Checks the PYTORCH_ROCM_ARCH environment variable first, since
+    `docker build` (and other build-only contexts) has no GPU device access,
+    so rocminfo always fails there and this would otherwise silently fall
+    back to the gfx942 default regardless of the actual build target. Only
+    falls back to querying rocminfo when PYTORCH_ROCM_ARCH is unset.
+
     Returns:
         str: The gfx code (e.g., 'gfx942', 'gfx90a'), or 'gfx942' as fallback.
     """
+    env_arch = os.environ.get("PYTORCH_ROCM_ARCH", "").strip()
+    if env_arch:
+        # PYTORCH_ROCM_ARCH may list multiple archs (comma/semicolon separated);
+        # take the first one since this function returns a single gfx code.
+        gfx_code = re.split(r"[,;]", env_arch)[0].strip()
+        print(f"Using PYTORCH_ROCM_ARCH from environment: {gfx_code}")
+        return gfx_code
     try:
         # Run rocminfo command
         result = subprocess.run(


### PR DESCRIPTION
# PR draft: `get_rocm_arch()` should check `PYTORCH_ROCM_ARCH` before shelling out to `rocminfo`

## Problem

`get_rocm_arch()` in `setup.py` unconditionally shells out to `rocminfo` to
detect the target GPU architecture, and only falls back to a hardcoded
`gfx942` default if that call fails for any reason (`CalledProcessError`,
`FileNotFoundError`, or any other exception).

`rocminfo` needs a live GPU device (`/dev/kfd`) to enumerate anything.
`docker build` never has device access, so in any container build context
`rocminfo` always fails and `get_rocm_arch()` always falls silently into
its `except` branch — returning `gfx942` regardless of what architecture
the image is actually being built for, even when the caller has explicitly
set `PYTORCH_ROCM_ARCH` for the whole build.

The failure mode is silent: the build succeeds, produces a `.so`, and only
fails later at runtime (or worse, loads but has no code objects for the
actual device and null-derefs on first kernel launch), with nothing in the
build log pointing back to `get_rocm_arch()` as the cause.

## Reproduction

Building this repo's own `docker/Dockerfile.rocm` with
`PYTORCH_ROCM_ARCH=gfx1151` set for the image previously produced a gsplat
`.so` compiled with `--offload-arch=gfx942` — the hardcoded fallback —
because `rocminfo` has no device to query at build time and the env var was
never consulted.

## Fix

Check `PYTORCH_ROCM_ARCH` first, and only fall back to querying `rocminfo`
when it's unset. This matches the general pattern of preferring an
explicit, caller-supplied build-target env var over runtime hardware
probing, which is the right precedence for any build context (including
plain `pip install` on a machine with multiple different GPUs) — not just
containers.

```python
env_arch = os.environ.get("PYTORCH_ROCM_ARCH", "").strip()
if env_arch:
    # PYTORCH_ROCM_ARCH may list multiple archs (comma/semicolon separated);
    # take the first one since this function returns a single gfx code.
    gfx_code = re.split(r"[,;]", env_arch)[0].strip()
    print(f"Using PYTORCH_ROCM_ARCH from environment: {gfx_code}")
    return gfx_code
try:
    # ... existing rocminfo path, unchanged ...
```

## Verification

Rebuilt `docker/Dockerfile.rocm` with `PYTORCH_ROCM_ARCH=gfx1151` set and no
`/dev/kfd` available at build time (standard `docker build`, no
`--device`). The resulting `.so` is now built with
`--offload-arch=gfx1151` as requested, instead of silently falling back to
`gfx942`.

## Overlap with #17

#17 independently hits the same bug and works around it inline at the call
site:

```python
gpu_arch = (os.environ.get("PYTORCH_ROCM_ARCH") or get_rocm_arch()).split(";")[0].split(",")[0].strip()
```

That's a correct fix for #17's own call site, but it only helps that one
caller — `get_rocm_arch()` itself still has the silent-`rocminfo`-fallback
behavior for anyone else calling it. Fixing `get_rocm_arch()` directly
means every current and future call site gets the env-var-first behavior
for free, and #17's call site could simplify back down to a plain
`get_rocm_arch()` call if this lands first. Posting this as a standalone
PR since it's independent of #17's kernel-level wave32 changes either way;
happy to rebase whichever of the two merges second.